### PR TITLE
Kill apps rather than asking them politely

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -132,7 +132,9 @@ class ForceQuitDialog extends ModalDialog.ModalDialog {
 
     _quitApp() {
         const app = this._selectedAppItem.app;
-        app.request_quit();
+        for (let window of app.get_windows()) {
+            window.kill();
+        }
         this.close();
     }
 


### PR DESCRIPTION
Previously, choosing Quit Application would call
shell_app_request_quit() on the app. Internally, this activates the 'app.quit' GAction on the app if one exists; and, if not, iterates over the app's windows, closing them all.

In the case of an app which stays running when all its windows are closed – notably including GNOME Software – this means that the app doesn't actually quit, just gets hidden. But if the app is in some broken state, such as GNOME Software having some long-running operation that doesn't end, this means the force-quit dialog doesn't help. When you reopen the app you'll get the same instance.

(This is the main case where this extension is useful: if an app doesn't respond to keyboard/mouse input for a few seconds, Mutter will already offer to kill it.)

Instead, iterate over all the app's windows and call meta_window_kill() on them. This kills the app in a window-system-determined way.

https://phabricator.endlessm.com/T34359